### PR TITLE
fix(shibboleth.spec): add provides user/group shibd, to fix build

### DIFF
--- a/common/SPECS/shibboleth.spec
+++ b/common/SPECS/shibboleth.spec
@@ -54,6 +54,8 @@ BuildRequires: libmemcached-devel
 %endif
 BuildRequires: redhat-rpm-config
 Requires(pre): shadow-utils
+Provides: user(shibd)
+Provides: group(shibd)
 %endif
 
 %define runuser shibd


### PR DESCRIPTION
```
==> Building SHIBRESOLVER on fedora43
docker run -it --rm -v /home/gitlab-runner/builds/joxYWs6fs/0/sysctl/release/cpp-linbuild/os/fedora43/products:/opt/build/external/out:z -v /home/gitlab-runner/builds/joxYWs6fs/0/sysctl/release/cpp-linbuild/common:/opt/build/external/in:z shibboleth/fedora43:base /bin/sh -e /opt/build/external/in/build.sh shibresolver
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
time="2026-04-22T13:51:51+02:00" level=warning msg="The input device is not a TTY. The --tty and --interactive flags might not work properly"
Fedora 43 - x86_64                               20 MB/s |  35 MB     00:01
Fedora 43 openh264 (From Cisco) - x86_64        7.5 kB/s | 1.8 kB     00:00
Fedora 43 - x86_64 - Updates                     15 MB/s | 9.3 MB     00:00
Local Shibboleth-SP Build Repo                  8.1 MB/s | 8.3 kB     00:00
Package gcc-c++-15.2.1-7.fc43.x86_64 is already installed.
Package krb5-devel-1.22.2-3.fc43.x86_64 is already installed.
Package pkgconf-pkg-config-2.3.0-3.fc43.x86_64 is already installed.
Package redhat-rpm-config-343-11.fc43.noarch is already installed.
Error:
 Problem: package shibboleth-devel-3.5.1-1.fc43.x86_64 from local requires shibboleth = 3.5.1-1.fc43, but none of the providers can be installed
  - package shibboleth-devel-3.5.1-1.fc43.x86_64 from local requires libshibsp-lite.so.12()(64bit), but none of the providers can be installed
  - package shibboleth-devel-3.5.1-1.fc43.x86_64 from local requires libshibsp.so.12()(64bit), but none of the providers can be installed
  - conflicting requests
  - nothing provides group(shibd) needed by shibboleth-3.5.1-1.fc43.x86_64 from local
  - nothing provides user(shibd) needed by shibboleth-3.5.1-1.fc43.x86_64 from local
```